### PR TITLE
Add required package to have ip command

### DIFF
--- a/.docker/.shared/scripts/install_software.sh
+++ b/.docker/.shared/scripts/install_software.sh
@@ -16,4 +16,5 @@ apt-get update -yqq && apt-get install -yqq \
     unzip \
     vim \
     wget \
+    iproute2 \
 ;


### PR DESCRIPTION
Without this the .docker/.shared/scripts/docker-entrypoint/resolve-docker-host-ip.sh script will not work since `HOST_IP=$(ip route | awk 'NR==1 {print $3}')` will return empty string.